### PR TITLE
Remove redundant Promise.resolve()

### DIFF
--- a/kb-better-graph-colors.js
+++ b/kb-better-graph-colors.js
@@ -60,8 +60,7 @@ const COLOR_SET = [
   "a04a9b",
 ];
 
-Promise.resolve()
-  .then(() => customElements.whenDefined("ha-chart-base"))
+customElements.whenDefined("ha-chart-base")
   .then(() => {
     const HaChartBase = customElements.get("ha-chart-base");
 


### PR DESCRIPTION
The `whenDefined()` method of the `CustomElementRegistry` interface returns a `Promise` that resolves when the named element is defined. It is not necessary to opt in to a Promise chain with an empty `Promise.resolve()`. See: https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/whenDefined